### PR TITLE
Revisions for code coverage (#10)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,3 +49,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Princeton-CDH/neuxml
+        # prevent uploading coverage for every python version
+        if: matrix.python == 3.12

--- a/README.rst
+++ b/README.rst
@@ -33,16 +33,15 @@ Installation
 
 We recommend using pip to install the officially released versions from PyPI:
 
-```console
-pip install neuxml
-```
+.. code-block:: shell
+  pip install neuxml
 
 It is also possible to install directly from GitHub. Use a branch or tag name,
 e.g. `@develop` or `@1.0` to install a specific tagged version or branch.
 
-```console
-pip install git+https://github.com/Princeton-CDH/neuxml.git@develop#egg=neuxml
-```
+.. code-block:: shell
+  pip install git+https://github.com/Princeton-CDH/neuxml.git@develop#egg=neuxml
+
 
 License
 =======

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # temporarily set project coverage to 86% while we improve; goal is 95%
+        target: 86%
+        threshold: 1%


### PR DESCRIPTION
Just realized there were a couple of things I missed in the last PR, for #10:
- Prevent the codecov upload step from running for any python version besides 3.12 (I figure that's our target)
- Set the minimum coverage to 86% for the project, for now

I also noticed there was some Markdown in the README that was messing up on the github render so I converted it to RST syntax.