### PR TITLE
Copyright notices: script and pre-commit hook (#13)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,6 @@ repos:
         name: check-copyright
         entry: python scripts/add_copyright.py --check
         language: python
+        # add_copyright.py only supports these for now; update list and script
+        # if more filetypes should be checked for copyright notices
+        types_or: ["python", "toml", "yaml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
@@ -8,3 +11,9 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: check-copyright
+        name: check-copyright
+        entry: python scripts/add_copyright.py --check
+        language: python

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
 coverage:
   status:
     project:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
 # Sphinx documentation build configuration file
 
 import neuxml

--- a/neuxml/__init__.py
+++ b/neuxml/__init__.py
@@ -1,7 +1,7 @@
 # file neuxml/__init__.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/__init__.py
+++ b/neuxml/__init__.py
@@ -1,5 +1,6 @@
 # file neuxml/__init__.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/catalog.py
+++ b/neuxml/catalog.py
@@ -1,7 +1,7 @@
 # file neuxml/catalog.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2016 Emory University Libraries
+#   Copyright 2016 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/catalog.py
+++ b/neuxml/catalog.py
@@ -1,5 +1,6 @@
 # file neuxml/catalog.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2016 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/__init__.py
+++ b/neuxml/xmlmap/__init__.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/__init__.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/__init__.py
+++ b/neuxml/xmlmap/__init__.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/__init__.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/cerp.py
+++ b/neuxml/xmlmap/cerp.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/cerp.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/cerp.py
+++ b/neuxml/xmlmap/cerp.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/cerp.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/core.py
+++ b/neuxml/xmlmap/core.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/core.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/core.py
+++ b/neuxml/xmlmap/core.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/core.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/dc.py
+++ b/neuxml/xmlmap/dc.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/dc.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/dc.py
+++ b/neuxml/xmlmap/dc.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/dc.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/eadmap.py
+++ b/neuxml/xmlmap/eadmap.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/eadmap.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/eadmap.py
+++ b/neuxml/xmlmap/eadmap.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/eadmap.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/fields.py
+++ b/neuxml/xmlmap/fields.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/fields.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/fields.py
+++ b/neuxml/xmlmap/fields.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/fields.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/mods.py
+++ b/neuxml/xmlmap/mods.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/mods.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/mods.py
+++ b/neuxml/xmlmap/mods.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/mods.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/premis.py
+++ b/neuxml/xmlmap/premis.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/premis.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/premis.py
+++ b/neuxml/xmlmap/premis.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/premis.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xmlmap/teimap.py
+++ b/neuxml/xmlmap/teimap.py
@@ -1,5 +1,6 @@
 # file neuxml/xmlmap/teimap.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xmlmap/teimap.py
+++ b/neuxml/xmlmap/teimap.py
@@ -1,7 +1,7 @@
 # file neuxml/xmlmap/teimap.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/__init__.py
+++ b/neuxml/xpath/__init__.py
@@ -1,5 +1,6 @@
 # file neuxml/xpath/__init__.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xpath/__init__.py
+++ b/neuxml/xpath/__init__.py
@@ -1,7 +1,7 @@
 # file neuxml/xpath/__init__.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/ast.py
+++ b/neuxml/xpath/ast.py
@@ -1,5 +1,6 @@
 # file neuxml/xpath/ast.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xpath/ast.py
+++ b/neuxml/xpath/ast.py
@@ -1,7 +1,7 @@
 # file neuxml/xpath/ast.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/core.py
+++ b/neuxml/xpath/core.py
@@ -1,7 +1,7 @@
 # file neuxml/xpath/core.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/core.py
+++ b/neuxml/xpath/core.py
@@ -1,5 +1,6 @@
 # file neuxml/xpath/core.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xpath/lexrules.py
+++ b/neuxml/xpath/lexrules.py
@@ -1,5 +1,6 @@
 # file neuxml/xpath/lexrules.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/neuxml/xpath/lexrules.py
+++ b/neuxml/xpath/lexrules.py
@@ -1,7 +1,7 @@
 # file neuxml/xpath/lexrules.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/parserules.py
+++ b/neuxml/xpath/parserules.py
@@ -1,7 +1,7 @@
 # file neuxml/xpath/parserules.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2010,2011 Emory University Libraries
+#   Copyright 2010,2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/neuxml/xpath/parserules.py
+++ b/neuxml/xpath/parserules.py
@@ -1,5 +1,6 @@
 # file neuxml/xpath/parserules.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2010,2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/scripts/add_copyright.py
+++ b/scripts/add_copyright.py
@@ -42,6 +42,7 @@ def main(arg_list=None):
         path = Path(filename)
         if (
             not path.is_file()  # skip non-files
+            or ".github" in path.parts  # skip github workflows
             or path.name in ["lextab.py", "parsetab.py"]  # skip generated PLY files
             or "schema_data" in path.parts  # skip schema_data/* (xml from elsewhere)
             # skip test fixtures

--- a/scripts/add_copyright.py
+++ b/scripts/add_copyright.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+import re
+from pathlib import Path
+
+# variables for adding copyright notice programmatically
+COPYRIGHT_YEAR = "2025"
+COPYRIGHT_HOLDER = "Center for Digital Humanities, Princeton University"
+COPYRIGHT_STATEMENT = f"Copyright {COPYRIGHT_YEAR} {COPYRIGHT_HOLDER}"
+SPDX_ID = "SPDX-License-Identifier: Apache-2.0"
+SUPPORTED_TYPES = [".py", ".yaml", ".yml", ".toml"]
+
+# regex to check if ANY copyright is present
+COPYRIGHT_RE = re.compile(r"^\s*#\s*[Cc]opyright", re.MULTILINE)
+
+# regex for existing emory copyright, keeping track of indentation
+EUL_RE = re.compile(r"^(\s*#\s*)Copyright [\d,]+ Emory University", re.MULTILINE)
+
+
+def main(arg_list=None):
+    """Add or check for copyright statements"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check files for copyright notice",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help="Filenames (may use glob pattern) to check or modify",
+    )
+    args = parser.parse_args(arg_list)
+
+    check = args.check
+    needs_copyright = []
+
+    for filename in args.filenames:
+        path = Path(filename)
+        if (
+            not path.is_file()  # skip non-files
+            or path.name in ["lextab.py", "parsetab.py"]  # skip generated PLY files
+            or "schema_data" in path.parts  # skip schema_data/* (xml from elsewhere)
+            # skip test fixtures
+            or any("fixtures" in part for part in path.parts if "test" in path.parts)
+        ):
+            continue
+
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            # skip unreadable/binary files
+            continue
+
+        if not COPYRIGHT_RE.search(contents):
+            # missing copyright: add to pre-commit check failures
+            needs_copyright.append(filename)
+            if not check and path.suffix in SUPPORTED_TYPES:
+                # automatically add CDH copyright with SPDX identifier
+                new_contents = f"# {COPYRIGHT_STATEMENT}\n# {SPDX_ID}\n\n{contents}"
+                path.write_text(new_contents)
+        elif not check and EUL_RE.search(contents):
+            # has EUL copyright: add CDH copyright directly above
+            new_contents = EUL_RE.sub(
+                lambda m: f"{m.group(1)}{COPYRIGHT_STATEMENT}\n{m.group(0)}",
+                contents,
+            )
+            path.write_text(new_contents)
+
+    if check:
+        # use exit code to tell pre-commit success or failure
+        if needs_copyright:
+            print("The following files are missing a copyright notice:")
+            for f in needs_copyright:
+                print(f" - {f}")
+            sys.exit(1)
+        print("All modified files have copyright notices.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Center for Digital Humanities, Princeton University
+# SPDX-License-Identifier: Apache-2.0
+
 from importlib import resources
 from lxml import etree
 import os

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -2,6 +2,7 @@
 
 # file test_xmlmap/test_core.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_catalog.py
+++ b/test/test_catalog.py
@@ -3,7 +3,7 @@
 # file test_xmlmap/test_core.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_cerp.py
+++ b/test/test_xmlmap/test_cerp.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_cerp.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_cerp.py
+++ b/test/test_xmlmap/test_cerp.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_cerp.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_core.py
+++ b/test/test_xmlmap/test_core.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_core.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_core.py
+++ b/test/test_xmlmap/test_core.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_core.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_dc.py
+++ b/test/test_xmlmap/test_dc.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_dc.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_dc.py
+++ b/test/test_xmlmap/test_dc.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_dc.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_ead.py
+++ b/test/test_xmlmap/test_ead.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_ead.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_ead.py
+++ b/test/test_xmlmap/test_ead.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_ead.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_fields.py
+++ b/test/test_xmlmap/test_fields.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_fields.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_fields.py
+++ b/test/test_xmlmap/test_fields.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_fields.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_mods.py
+++ b/test/test_xmlmap/test_mods.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_mods.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_mods.py
+++ b/test/test_xmlmap/test_mods.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_mods.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_premis.py
+++ b/test/test_xmlmap/test_premis.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_premis.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xmlmap/test_premis.py
+++ b/test/test_xmlmap/test_premis.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_premis.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_tei.py
+++ b/test/test_xmlmap/test_tei.py
@@ -1,7 +1,7 @@
 # file test_xmlmap/test_tei.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xmlmap/test_tei.py
+++ b/test/test_xmlmap/test_tei.py
@@ -1,5 +1,6 @@
 # file test_xmlmap/test_tei.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_xpath.py
+++ b/test/test_xpath.py
@@ -3,7 +3,7 @@
 # file test_xpath.py
 #
 #   Copyright 2025 Center for Digital Humanities, Princeton University
-#   Copyright 2011 Emory University Libraries
+#   Copyright 2011 Emory University Libraries (eulxml)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/test/test_xpath.py
+++ b/test/test_xpath.py
@@ -2,6 +2,7 @@
 
 # file test_xpath.py
 #
+#   Copyright 2025 Center for Digital Humanities, Princeton University
 #   Copyright 2011 Emory University Libraries
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**Associated Issue(s):** #13

### Changes in this PR

- Add script that can add a copyright notice to all files missing it, or which only have the Emory notice
- Allow the `--check` argument to report on files missing notices (in this mode, will not modify files)
- Add a pre-commit hook that runs the script with `--check` on all new/changed files, which will fail if notices are missing
- Run the script against the entire repo to produce missing copyright notices

### Notes

- I used the SPDX shorthand for adding notices to files that don't have one, does that make sense to you or should we be more consistent and use the old long-form notice?
- Should I add unit tests for the script?
- For now the script only supports `#` style comments in python, yaml, and toml; running against the whole repo with `--check` shows these additional files missing notices. Let me know if I should address or if it's ok for now.
   <details> <summary> Missing copyright report</summary>

    ```
    The following files are missing a copyright notice:
    - ./CHANGELOG.rst
    - ./DEVNOTES.rst
    - ./MIGRATION.rst
    - ./README.rst
    - ./pytest.ini
    - ./doc/Makefile
    - ./doc/_static/style.css
    - ./doc/build/html/_sources/catalog.rst.txt
    - ./doc/build/html/_sources/changelog.rst.txt
    - ./doc/build/html/_sources/index.rst.txt
    - ./doc/build/html/_sources/xmlmap.rst.txt
    - ./doc/build/html/_sources/xmlmap/cerp.rst.txt
    - ./doc/build/html/_sources/xmlmap/dc.rst.txt
    - ./doc/build/html/_sources/xmlmap/ead.rst.txt
    - ./doc/build/html/_sources/xmlmap/mods.rst.txt
    - ./doc/build/html/_sources/xmlmap/premis.rst.txt
    - ./doc/build/html/_sources/xpath.rst.txt
    - ./doc/build/html/_static/alabaster.css
    - ./doc/build/html/_static/basic.css
    - ./doc/build/html/_static/custom.css
    - ./doc/build/html/_static/doctools.js
    - ./doc/build/html/_static/documentation_options.js
    - ./doc/build/html/_static/github-banner.svg
    - ./doc/build/html/_static/language_data.js
    - ./doc/build/html/_static/pygments.css
    - ./doc/build/html/_static/searchtools.js
    - ./doc/build/html/_static/sphinx_highlight.js
    - ./doc/build/html/_static/style.css
    - ./doc/build/html/catalog.html
    - ./doc/build/html/changelog.html
    - ./doc/build/html/genindex.html
    - ./doc/build/html/index.html
    - ./doc/build/html/py-modindex.html
    - ./doc/build/html/search.html
    - ./doc/build/html/searchindex.js
    - ./doc/build/html/xmlmap.html
    - ./doc/build/html/xmlmap/cerp.html
    - ./doc/build/html/xmlmap/dc.html
    - ./doc/build/html/xmlmap/ead.html
    - ./doc/build/html/xmlmap/mods.html
    - ./doc/build/html/xmlmap/premis.html
    - ./doc/build/html/xpath.html
    - ./doc/catalog.rst
    - ./doc/changelog.rst
    - ./doc/index.rst
    - ./doc/templates/sidebar_footer.html
    - ./doc/xmlmap.rst
    - ./doc/xmlmap/cerp.rst
    - ./doc/xmlmap/dc.rst
    - ./doc/xmlmap/ead.rst
    - ./doc/xmlmap/mods.rst
    - ./doc/xmlmap/premis.rst
    - ./doc/xpath.rst
    ```
   </details>