### PR TITLE
Upgrade lxml, add dublin core schemas to catalog, and bind refresh catalog method as script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change & Version Information
 ============================
 
+1.1
+---
+
+* Requires lxml 6.0 or greater, which enforces `no_network` by default when parsing
+* XML catalog files have been updated and now include Dublin Core schemas.
+
+
 1.0.0
 -----
 

--- a/neuxml/catalog.py
+++ b/neuxml/catalog.py
@@ -21,9 +21,9 @@ Logic for downloading local copies of schemas and generating an
 resolving schemas locally instead of downloading them every time validation
 is required.
 
-Catalog generation is available via the setup.py custom command xmlcatalog,
-and a generated catalog and corresponding schema files should be included
-in packaged releases of neuxml.
+Catalog generation is available via the script `neuxml-refresh-catalog`;
+a catalog and corresponding schema files for supported formats is
+included in packaged releases of neuxml.
 
 For more information about setting up and testing XML catalogs, see the
 `libxml2 documentation <http://xmlsoft.org/catalog.html>`_.
@@ -66,6 +66,8 @@ XSD_SCHEMAS = [
     "http://www.w3.org/2001/xml.xsd",
     "http://www.w3.org/2001/03/xml.xsd",
     "http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd",
+    "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+    "http://dublincore.org/schemas/xmls/simpledc20021212.xsd",
 ]
 # Deprecated URLs. Current schema lives on Github at https://github.com/StateArchivesOfNorthCarolina/tomes-eaxs.
 # 'http://www.archives.ncdcr.gov/mail-account.xsd',
@@ -155,7 +157,7 @@ def refresh_catalog(xsd_schemas=None, xmlcatalog_dir=None, xmlcatalog_file=None)
 
     .. Note::
 
-        Currently this method overwites any existing schema and catalog
+        Currently this method overwrites any existing schema and catalog
         files, without checking if they are present or need to be
         updated.
 

--- a/neuxml/schema_data/catalog.xml
+++ b/neuxml/schema_data/catalog.xml
@@ -1,16 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <c:catalog xmlns:c="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <c:uri name="http://www.loc.gov/standards/mods/mods.xsd" uri="mods.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/mods/v3/mods-3-4.xsd" uri="mods-3-4.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/xlink/xlink.xsd" uri="xlink.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/premis/premis.xsd" uri="premis.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" uri="premis-v2-1.xsd"/>
-    <c:uri name="http://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" uri="tei_all.xsd"/>
-    <c:uri name="https://raw.githubusercontent.com/StateArchivesOfNorthCarolina/tomes-eaxs/master/versions/1/eaxs_schema_v1.xsd" uri="eaxs_schema_v1.xsd"/>
-    <c:uri name="http://www.openarchives.org/OAI/2.0/oai_dc.xsd" uri="oai_dc.xsd"/>
-    <c:uri name="http://www.loc.gov/ead/ead.xsd" uri="ead.xsd"/>
-    <c:uri name="http://www.loc.gov/mods/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.w3.org/2001/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.w3.org/2001/03/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd" uri="simpledc20021212.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/mods/mods.xsd" uri="mods.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/mods/v3/mods-3-4.xsd" uri="mods-3-4.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/xlink/xlink.xsd" uri="xlink.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/premis/premis.xsd" uri="premis.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" uri="premis-v2-1.xsd"/>
+  <c:uri name="http://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" uri="tei_all.xsd"/>
+  <c:uri name="https://raw.githubusercontent.com/StateArchivesOfNorthCarolina/tomes-eaxs/master/versions/1/eaxs_schema_v1.xsd" uri="eaxs_schema_v1.xsd"/>
+  <c:uri name="http://www.loc.gov/ead/ead.xsd" uri="ead.xsd"/>
+  <c:uri name="http://www.loc.gov/mods/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://www.w3.org/2001/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://www.w3.org/2001/03/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd" uri="simpledc20021212.xsd"/>
+  <c:uri name="http://www.openarchives.org/OAI/2.0/oai_dc.xsd" uri="oai_dc.xsd"/>
+  <c:uri name="http://dublincore.org/schemas/xmls/simpledc20021212.xsd" uri="simpledc20021212.xsd"/>
 </c:catalog>

--- a/neuxml/schema_data/ead.xsd
+++ b/neuxml/schema_data/ead.xsd
@@ -1847,4 +1847,4 @@
 		<xs:attributeGroup ref="a.common"/>
 		<xs:attributeGroup ref="xlink:resourceLink"/>
 	</xs:complexType>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/eaxs_schema_v1.xsd
+++ b/neuxml/schema_data/eaxs_schema_v1.xsd
@@ -522,4 +522,4 @@
 	</simpleType>
 
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></schema>

--- a/neuxml/schema_data/mods-3-4.xsd
+++ b/neuxml/schema_data/mods-3-4.xsd
@@ -1710,4 +1710,4 @@ Therefore, two definitions are needed for the usage attribute, one for <url> ("u
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/mods.xsd
+++ b/neuxml/schema_data/mods.xsd
@@ -1767,4 +1767,4 @@ String Definitions
 		</xs:restriction>
 	</xs:simpleType>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/oai_dc.xsd
+++ b/neuxml/schema_data/oai_dc.xsd
@@ -1,41 +1,37 @@
-<schema targetNamespace="http://www.openarchives.org/OAI/2.0/oai_dc/" 
-        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" 
-        xmlns:dc="http://purl.org/dc/elements/1.1/" 
-        xmlns="http://www.w3.org/2001/XMLSchema" 
-        elementFormDefault="qualified" attributeFormDefault="unqualified">
-        
-    <annotation>
-        <documentation> 
-            XML Schema 2002-03-18 by Pete Johnston.
-            Adjusted for usage in the OAI-PMH.
-            Schema imports the Dublin Core elements from the DCMI schema for unqualified Dublin Core.
-            2002-12-19 updated to use simpledc20021212.xsd (instead of simpledc20020312.xsd)
-        </documentation>
-    </annotation>
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.openarchives.org/OAI/2.0/oai_dc/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	
+<annotation>
+  <documentation> 
+      XML Schema 2002-03-18 by Pete Johnston.
+      Adjusted for usage in the OAI-PMH.
+      Schema imports the Dublin Core elements from the DCMI schema for unqualified Dublin Core.
+      2002-12-19 updated to use simpledc20021212.xsd (instead of simpledc20020312.xsd)
+  </documentation>
+</annotation>
 
-    <import namespace="http://purl.org/dc/elements/1.1/" 
-            schemaLocation="http://dublincore.org/schemas/xmls/simpledc20021212.xsd"/>
+<import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/simpledc20021212.xsd"/>
+	
+<element name="dc" type="oai_dc:oai_dcType"/>
 
-    <element name="dc" type="oai_dc:oai_dcType"/>
+<complexType name="oai_dcType">
+  <choice minOccurs="0" maxOccurs="unbounded">
+    <element ref="dc:title"/>
+    <element ref="dc:creator"/>
+    <element ref="dc:subject"/>
+    <element ref="dc:description"/>
+    <element ref="dc:publisher"/>
+    <element ref="dc:contributor"/>
+    <element ref="dc:date"/>
+    <element ref="dc:type"/>
+    <element ref="dc:format"/>
+    <element ref="dc:identifier"/>
+    <element ref="dc:source"/>
+    <element ref="dc:language"/>
+    <element ref="dc:relation"/>
+    <element ref="dc:coverage"/>
+    <element ref="dc:rights"/>
+  </choice>
+</complexType>
 
-    <complexType name="oai_dcType">
-        <choice minOccurs="0" maxOccurs="unbounded">
-            <element ref="dc:title"/>
-            <element ref="dc:creator"/>
-            <element ref="dc:subject"/>
-            <element ref="dc:description"/>
-            <element ref="dc:publisher"/>
-            <element ref="dc:contributor"/>
-            <element ref="dc:date"/>
-            <element ref="dc:type"/>
-            <element ref="dc:format"/>
-            <element ref="dc:identifier"/>
-            <element ref="dc:source"/>
-            <element ref="dc:language"/>
-            <element ref="dc:relation"/>
-            <element ref="dc:coverage"/>
-            <element ref="dc:rights"/>
-        </choice>
-    </complexType>
-
-</schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></schema>

--- a/neuxml/schema_data/premis-v2-1.xsd
+++ b/neuxml/schema_data/premis-v2-1.xsd
@@ -1254,4 +1254,4 @@ Element Declarations
 	<xs:element name="mdWrap" type="mdWrapDefinition"/>
 	<xs:element name="xmlData" type="xmlDataDefinition"/>
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/premis.xsd
+++ b/neuxml/schema_data/premis.xsd
@@ -1215,4 +1215,4 @@ It is introduced to reinforce this recommendation.)
 	</xs:complexType>
 	
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/simpledc20021212.xsd
+++ b/neuxml/schema_data/simpledc20021212.xsd
@@ -69,4 +69,4 @@
     </xs:simpleContent>
   </xs:complexType>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/tei_all.xsd
+++ b/neuxml/schema_data/tei_all.xsd
@@ -24993,4 +24993,4 @@ Suggested values include: 1] schematron (ISO Schematron)</xs:documentation>
       <xs:attributeGroup ref="tei:att.global.attributes"/>
     </xs:complexType>
   </xs:element>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/neuxml/schema_data/xlink.xsd
+++ b/neuxml/schema_data/xlink.xsd
@@ -72,4 +72,4 @@
   <attributeGroup name="emptyLink">
     <attribute name="type" type="string" fixed="none" form="qualified"/> 
   </attributeGroup>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></schema>

--- a/neuxml/schema_data/xml.xsd
+++ b/neuxml/schema_data/xml.xsd
@@ -113,4 +113,4 @@
   <xs:attribute ref="xml:space"/>
  </xs:attributeGroup>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></xs:schema>
+<!--Downloaded by neuxml 1.0.0 on 2025-07-08--></xs:schema>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
 Repository = "https://github.com/Princeton-CDH/neuxml"
 Changelog = "https://github.com/Princeton-CDH/neuxml/blob/main/CHANGELOG.rst"
 
+[project.scripts]
+neuxml-refresh-catalog = "neuxml.catalog:refresh_catalog"
+
 [tool.hatch.build]
 artifacts = ["neuxml/xpath/lextab.py", "neuxml/xpath/parsetab.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup :: XML",
 ]
-dependencies = ["ply>=3.8", "lxml>=3.4", "rdflib>=3.0"]
+dependencies = ["ply>=3.8", "lxml>=6.0", "rdflib>=3.0"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
**Associated Issue(s):** #

### Changes in this PR

- require lxml 6.0 or greater
- add dublin core schemas to catalog list
- bind refresh_catalog method as a project script in pyproject.toml
- update catalog + schema files

### Notes / questions

- Was there a previous method for updating schema catalog files? I remember some discussion of it during the release prep but not our decision
- Any concerns about requiring lxml 6.0 ? Might this cause compatibility issues in other apps?

### Reviewer Checklist
In addition to reviewing code changes:

- [x] Check that you can run the refresh catalog script after installing a local copy
- [x] Optional: run pytest locally on this branch with lxml 6.0 to confirm no errors (expect this to match GitHub Actions)
