### PR TITLE
Update catalog, add cli access to refresh, make rdflib optional

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
+        rdflib: [true, false]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,10 +34,14 @@ jobs:
             pip-${{ hashFiles('pyproject.toml') }}
             pip-
 
-      - name: Install package with dependencies
+      - name: Install package with test dependencies
         run: |
-          pip install -e '.[dev]'
+          pip install -e '.[test]'
           pip install codecov
+
+      - name: Install package with rdf dependencies if enabled
+        if: ${{ matrix.rdflib }}
+        run: pip install -e '.[rdf]'
 
       - name: Generate PLY lextab and parsetab artifacts
         run: python -c "import neuxml.xpath.core"

--- a/DEVNOTES.rst
+++ b/DEVNOTES.rst
@@ -59,3 +59,9 @@ in that module, and store the schemas and catalog file in the subdirectory
 
 To specify other remote schema URLs and catalog locations, use the provided
 keyword arguments ``xsd_schemas``, ``xmlcatalog_dir``, and ``xmlcatalog_file``.
+
+To refresh the defaults, use the project script which calls the same method:
+
+.. code-block:: shell
+
+    neuxml-refresh-catalog

--- a/neuxml/catalog.py
+++ b/neuxml/catalog.py
@@ -65,7 +65,10 @@ XSD_SCHEMAS = [
     "http://www.loc.gov/mods/xml.xsd",
     "http://www.w3.org/2001/xml.xsd",
     "http://www.w3.org/2001/03/xml.xsd",
-    "http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd",
+    # "http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd",
+    "http://dublincore.org/schemas/xmls/simpledc20021212.xsd",
+    "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+    "http://dublincore.org/2010/10/11/dctype.rdf",
 ]
 # Deprecated URLs. Current schema lives on Github at https://github.com/StateArchivesOfNorthCarolina/tomes-eaxs.
 # 'http://www.archives.ncdcr.gov/mail-account.xsd',
@@ -137,7 +140,7 @@ def download_schema(uri, path, comment=None):
     except requests.exceptions.HTTPError as err:
         msg = "Failed to download schema %s" % schema
         msg += "(error codes %s)" % err.response.status_code
-        logger.warn(msg)
+        logger.warning(msg)
 
         return False
 
@@ -203,3 +206,14 @@ def refresh_catalog(xsd_schemas=None, xmlcatalog_dir=None, xmlcatalog_file=None)
         with open(xmlcatalog_file, "wb") as xml_catalog:
             catalog.serializeDocument(xml_catalog, pretty=True)
     return catalog
+
+
+def refresh_cli():
+    """
+    Command line access to :meth:`refresh_catalog`. Configures logging
+    for `neuxml` to DEBUG level so downloads will be reported.
+    """
+    # configure logging with minimal format to output downloads and any errors
+    logging.basicConfig(format="%(message)s", level=logging.WARNING)
+    logging.getLogger("neuxml").setLevel(logging.DEBUG)
+    refresh_catalog()

--- a/neuxml/schema_data/catalog.xml
+++ b/neuxml/schema_data/catalog.xml
@@ -1,16 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <c:catalog xmlns:c="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <c:uri name="http://www.loc.gov/standards/mods/mods.xsd" uri="mods.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/mods/v3/mods-3-4.xsd" uri="mods-3-4.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/xlink/xlink.xsd" uri="xlink.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/premis/premis.xsd" uri="premis.xsd"/>
-    <c:uri name="http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" uri="premis-v2-1.xsd"/>
-    <c:uri name="http://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" uri="tei_all.xsd"/>
-    <c:uri name="https://raw.githubusercontent.com/StateArchivesOfNorthCarolina/tomes-eaxs/master/versions/1/eaxs_schema_v1.xsd" uri="eaxs_schema_v1.xsd"/>
-    <c:uri name="http://www.openarchives.org/OAI/2.0/oai_dc.xsd" uri="oai_dc.xsd"/>
-    <c:uri name="http://www.loc.gov/ead/ead.xsd" uri="ead.xsd"/>
-    <c:uri name="http://www.loc.gov/mods/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.w3.org/2001/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.w3.org/2001/03/xml.xsd" uri="xml.xsd"/>
-    <c:uri name="http://www.dublincore.org/schemas/xmls/simpledc20021212.xsd" uri="simpledc20021212.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/mods/mods.xsd" uri="mods.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/mods/v3/mods-3-4.xsd" uri="mods-3-4.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/xlink/xlink.xsd" uri="xlink.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/premis/premis.xsd" uri="premis.xsd"/>
+  <c:uri name="http://www.loc.gov/standards/premis/v2/premis-v2-1.xsd" uri="premis-v2-1.xsd"/>
+  <c:uri name="http://www.tei-c.org/release/xml/tei/custom/schema/xsd/tei_all.xsd" uri="tei_all.xsd"/>
+  <c:uri name="https://raw.githubusercontent.com/StateArchivesOfNorthCarolina/tomes-eaxs/master/versions/1/eaxs_schema_v1.xsd" uri="eaxs_schema_v1.xsd"/>
+  <c:uri name="http://www.loc.gov/ead/ead.xsd" uri="ead.xsd"/>
+  <c:uri name="http://www.loc.gov/mods/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://www.w3.org/2001/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://www.w3.org/2001/03/xml.xsd" uri="xml.xsd"/>
+  <c:uri name="http://dublincore.org/schemas/xmls/simpledc20021212.xsd" uri="simpledc20021212.xsd"/>
+  <c:uri name="http://www.openarchives.org/OAI/2.0/oai_dc.xsd" uri="oai_dc.xsd"/>
+  <c:uri name="http://dublincore.org/2010/10/11/dctype.rdf" uri="dctype.rdf"/>
 </c:catalog>

--- a/neuxml/schema_data/dctype.rdf
+++ b/neuxml/schema_data/dctype.rdf
@@ -1,0 +1,142 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcam="http://purl.org/dc/dcam/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/">
+<dcterms:title xml:lang="en-US">DCMI Type Vocabulary</dcterms:title>
+<dcterms:publisher rdf:resource="http://purl.org/dc/aboutdcmi#DCMI"/>
+<dcterms:modified>2010-10-11</dcterms:modified>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Collection">
+<rdfs:label xml:lang="en-US">Collection</rdfs:label>
+<rdfs:comment xml:lang="en-US">An aggregation of resources.</rdfs:comment>
+<dcterms:description xml:lang="en-US">A collection is described as a group; its parts may also be separately described.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Collection-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Dataset">
+<rdfs:label xml:lang="en-US">Dataset</rdfs:label>
+<rdfs:comment xml:lang="en-US">Data encoded in a defined structure.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include lists, tables, and databases.  A dataset may be useful for direct machine processing.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Dataset-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Event">
+<rdfs:label xml:lang="en-US">Event</rdfs:label>
+<rdfs:comment xml:lang="en-US">A non-persistent, time-based occurrence.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Metadata for an event provides descriptive information that is the basis for discovery of the purpose, location, duration, and responsible agents associated with an event. Examples include an exhibition, webcast, conference, workshop, open day, performance, battle, trial, wedding, tea party, conflagration.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Event-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Image">
+<rdfs:label xml:lang="en-US">Image</rdfs:label>
+<rdfs:comment xml:lang="en-US">A visual representation other than text.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include images and photographs of physical objects, paintings, prints, drawings, other images and graphics, animations and moving pictures, film, diagrams, maps, musical notation.  Note that Image may include both electronic and physical representations.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Image-004"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/InteractiveResource">
+<rdfs:label xml:lang="en-US">Interactive Resource</rdfs:label>
+<rdfs:comment xml:lang="en-US">A resource requiring interaction from the user to be understood, executed, or experienced.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include forms on Web pages, applets, multimedia learning objects, chat services, or virtual reality environments.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#InteractiveResource-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Service">
+<rdfs:label xml:lang="en-US">Service</rdfs:label>
+<rdfs:comment xml:lang="en-US">A system that provides one or more functions.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include a photocopying service, a banking service, an authentication service, interlibrary loans, a Z39.50 or Web server.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Service-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Software">
+<rdfs:label xml:lang="en-US">Software</rdfs:label>
+<rdfs:comment xml:lang="en-US">A computer program in source or compiled form.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include a C source file, MS-Windows .exe executable, or Perl script.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Software-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Sound">
+<rdfs:label xml:lang="en-US">Sound</rdfs:label>
+<rdfs:comment xml:lang="en-US">A resource primarily intended to be heard.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include a music playback file format, an audio compact disc, and recorded speech or sounds.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Sound-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/Text">
+<rdfs:label xml:lang="en-US">Text</rdfs:label>
+<rdfs:comment xml:lang="en-US">A resource consisting primarily of words for reading.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include books, letters, dissertations, poems, newspapers, articles, archives of mailing lists. Note that facsimiles or images of texts are still of the genre Text.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2000-07-11</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#Text-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/PhysicalObject">
+<rdfs:label xml:lang="en-US">Physical Object</rdfs:label>
+<rdfs:comment xml:lang="en-US">An inanimate, three-dimensional object or substance.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Note that digital representations of, or surrogates for, these objects should use Image, Text or one of the other types.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2002-07-13</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#PhysicalObject-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/StillImage">
+<rdfs:label xml:lang="en-US">Still Image</rdfs:label>
+<rdfs:comment xml:lang="en-US">A static visual representation.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include paintings, drawings, graphic designs, plans and maps. Recommended best practice is to assign the type Text to images of textual materials. Instances of the type Still Image must also be describable as instances of the broader type Image.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2003-11-18</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#StillImage-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+<rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/Image"/>
+</rdf:Description>
+<rdf:Description rdf:about="http://purl.org/dc/dcmitype/MovingImage">
+<rdfs:label xml:lang="en-US">Moving Image</rdfs:label>
+<rdfs:comment xml:lang="en-US">A series of visual representations imparting an impression of motion when shown in succession.</rdfs:comment>
+<dcterms:description xml:lang="en-US">Examples include animations, movies, television programs, videos, zoetropes, or visual output from a simulation.  Instances of the type Moving Image must also be describable as instances of the broader type Image.</dcterms:description>
+<rdfs:isDefinedBy rdf:resource="http://purl.org/dc/dcmitype/"/>
+<dcterms:issued>2003-11-18</dcterms:issued>
+<dcterms:modified>2008-01-14</dcterms:modified>
+<rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+<dcterms:hasVersion rdf:resource="http://dublincore.org/usage/terms/history/#MovingImage-003"/>
+<dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+<rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/Image"/>
+</rdf:Description>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></rdf:RDF>

--- a/neuxml/schema_data/ead.xsd
+++ b/neuxml/schema_data/ead.xsd
@@ -1847,4 +1847,4 @@
 		<xs:attributeGroup ref="a.common"/>
 		<xs:attributeGroup ref="xlink:resourceLink"/>
 	</xs:complexType>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/eaxs_schema_v1.xsd
+++ b/neuxml/schema_data/eaxs_schema_v1.xsd
@@ -522,4 +522,4 @@
 	</simpleType>
 
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></schema>

--- a/neuxml/schema_data/mods-3-4.xsd
+++ b/neuxml/schema_data/mods-3-4.xsd
@@ -1710,4 +1710,4 @@ Therefore, two definitions are needed for the usage attribute, one for <url> ("u
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/mods.xsd
+++ b/neuxml/schema_data/mods.xsd
@@ -1767,4 +1767,4 @@ String Definitions
 		</xs:restriction>
 	</xs:simpleType>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/oai_dc.xsd
+++ b/neuxml/schema_data/oai_dc.xsd
@@ -1,41 +1,37 @@
-<schema targetNamespace="http://www.openarchives.org/OAI/2.0/oai_dc/" 
-        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" 
-        xmlns:dc="http://purl.org/dc/elements/1.1/" 
-        xmlns="http://www.w3.org/2001/XMLSchema" 
-        elementFormDefault="qualified" attributeFormDefault="unqualified">
-        
-    <annotation>
-        <documentation> 
-            XML Schema 2002-03-18 by Pete Johnston.
-            Adjusted for usage in the OAI-PMH.
-            Schema imports the Dublin Core elements from the DCMI schema for unqualified Dublin Core.
-            2002-12-19 updated to use simpledc20021212.xsd (instead of simpledc20020312.xsd)
-        </documentation>
-    </annotation>
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.openarchives.org/OAI/2.0/oai_dc/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	
+<annotation>
+  <documentation> 
+      XML Schema 2002-03-18 by Pete Johnston.
+      Adjusted for usage in the OAI-PMH.
+      Schema imports the Dublin Core elements from the DCMI schema for unqualified Dublin Core.
+      2002-12-19 updated to use simpledc20021212.xsd (instead of simpledc20020312.xsd)
+  </documentation>
+</annotation>
 
-    <import namespace="http://purl.org/dc/elements/1.1/" 
-            schemaLocation="http://dublincore.org/schemas/xmls/simpledc20021212.xsd"/>
+<import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/simpledc20021212.xsd"/>
+	
+<element name="dc" type="oai_dc:oai_dcType"/>
 
-    <element name="dc" type="oai_dc:oai_dcType"/>
+<complexType name="oai_dcType">
+  <choice minOccurs="0" maxOccurs="unbounded">
+    <element ref="dc:title"/>
+    <element ref="dc:creator"/>
+    <element ref="dc:subject"/>
+    <element ref="dc:description"/>
+    <element ref="dc:publisher"/>
+    <element ref="dc:contributor"/>
+    <element ref="dc:date"/>
+    <element ref="dc:type"/>
+    <element ref="dc:format"/>
+    <element ref="dc:identifier"/>
+    <element ref="dc:source"/>
+    <element ref="dc:language"/>
+    <element ref="dc:relation"/>
+    <element ref="dc:coverage"/>
+    <element ref="dc:rights"/>
+  </choice>
+</complexType>
 
-    <complexType name="oai_dcType">
-        <choice minOccurs="0" maxOccurs="unbounded">
-            <element ref="dc:title"/>
-            <element ref="dc:creator"/>
-            <element ref="dc:subject"/>
-            <element ref="dc:description"/>
-            <element ref="dc:publisher"/>
-            <element ref="dc:contributor"/>
-            <element ref="dc:date"/>
-            <element ref="dc:type"/>
-            <element ref="dc:format"/>
-            <element ref="dc:identifier"/>
-            <element ref="dc:source"/>
-            <element ref="dc:language"/>
-            <element ref="dc:relation"/>
-            <element ref="dc:coverage"/>
-            <element ref="dc:rights"/>
-        </choice>
-    </complexType>
-
-</schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></schema>

--- a/neuxml/schema_data/premis-v2-1.xsd
+++ b/neuxml/schema_data/premis-v2-1.xsd
@@ -1254,4 +1254,4 @@ Element Declarations
 	<xs:element name="mdWrap" type="mdWrapDefinition"/>
 	<xs:element name="xmlData" type="xmlDataDefinition"/>
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/premis.xsd
+++ b/neuxml/schema_data/premis.xsd
@@ -1215,4 +1215,4 @@ It is introduced to reinforce this recommendation.)
 	</xs:complexType>
 	
 	<!-- -->
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/simpledc20021212.xsd
+++ b/neuxml/schema_data/simpledc20021212.xsd
@@ -69,4 +69,4 @@
     </xs:simpleContent>
   </xs:complexType>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/tei_all.xsd
+++ b/neuxml/schema_data/tei_all.xsd
@@ -3,9 +3,9 @@
   <xs:import namespace="http://www.tei-c.org/ns/Examples" schemaLocation="tei_all_teix.xsd"/>
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="tei_all_xml.xsd"/>
   <!--
-    Schema generated from ODD source 2025-01-24T19:58:43Z. . 
-    TEI Edition: P5 Version 4.9.0. Last updated on 24th January 2025, revision f73186978 
-    TEI Edition Location: https://www.tei-c.org/Vault/P5/4.9.0/ 
+    Schema generated from ODD source 2025-08-15T13:47:36Z. . 
+    TEI Edition: P5 Version 4.10.0. Last updated on 15th August 2025, revision ebf0834e1 
+    TEI Edition Location: https://www.tei-c.org/Vault/P5/4.10.0/ 
     
   -->
   <!-- TEI material can be licensed differently depending on the use you intend to make of it. Hence it is made available under both the CC+BY and BSD-2 licences. The CC+BY licence is generally appropriate for usages which treat TEI content as data or documentation. The BSD-2 licence is generally appropriate for usage of TEI content in a software environment. For further information or clarification, please contact the TEI Consortium (info@tei-c.org). -->
@@ -203,7 +203,7 @@
   <xs:attributeGroup name="att.citing.attribute.unit">
     <xs:attribute name="unit">
       <xs:annotation>
-        <xs:documentation>identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
+        <xs:documentation>identifies the unit of information conveyed by the element.
 Suggested values include: 1] volume (volume); 2] issue; 3] page (page); 4] line; 5] chapter (chapter); 6] part; 7] column; 8] entry</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
@@ -7514,8 +7514,11 @@ Sample values include: 1] main; 2] sub (subordinate); 3] alt (alternate); 4] sho
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
-        <xs:sequence minOccurs="0">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:group ref="tei:model.global"/>
+          <xs:group ref="tei:model.stageLike"/>
+        </xs:choice>
+        <xs:sequence>
           <xs:element ref="tei:speaker"/>
           <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.global"/>
         </xs:sequence>
@@ -9962,11 +9965,12 @@ Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5
   </xs:element>
   <xs:element name="closer">
     <xs:annotation>
-      <xs:documentation>(closer) groups together salutations, datelines, and similar phrases appearing as a final group at the end of a division, especially of a letter. [4.2.2. Openers and Closers 4.2. Elements Common to All Divisions]</xs:documentation>
+      <xs:documentation>(closer) groups together salutations, datelines, bylines, and similar phrases appearing as a final group at the end of a division, especially of a letter. [4.2.2. Openers and Closers 4.2. Elements Common to All Divisions]</xs:documentation>
     </xs:annotation>
     <xs:complexType mixed="true">
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:group ref="tei:model.gLike"/>
+        <xs:element ref="tei:byline"/>
         <xs:element ref="tei:signed"/>
         <xs:element ref="tei:dateline"/>
         <xs:element ref="tei:salute"/>
@@ -16504,10 +16508,13 @@ Suggested values include: 1] paper; 2] parch (parchment); 3] mixed</xs:documenta
     <xs:complexType>
       <xs:sequence>
         <xs:element minOccurs="0" ref="tei:front"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:group ref="tei:model.graphicLike"/>
-          <xs:element ref="tei:surface"/>
-          <xs:element ref="tei:surfaceGrp"/>
+        <xs:choice>
+          <xs:choice maxOccurs="unbounded">
+            <xs:group ref="tei:model.graphicLike"/>
+            <xs:element ref="tei:surface"/>
+            <xs:element ref="tei:surfaceGrp"/>
+          </xs:choice>
+          <xs:element maxOccurs="unbounded" ref="tei:facsimile"/>
         </xs:choice>
         <xs:element minOccurs="0" ref="tei:back"/>
       </xs:sequence>
@@ -16602,7 +16609,17 @@ Sample values include: 1] glued; 2] pinned; 3] sewn</xs:documentation>
       <xs:attributeGroup ref="tei:att.coordinated.attributes"/>
       <xs:attributeGroup ref="tei:att.typed.attributes"/>
       <xs:attributeGroup ref="tei:att.written.attributes"/>
-      <xs:attribute name="rotate" default="0" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="rotate" default="0">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:double xs:decimal">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:pattern value="(\-?[\d]+/\-?[\d]+)"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="path">
@@ -18404,10 +18421,10 @@ Sample values include: 1] primary; 2] secondary; 3] undergraduate; 4] graduate; 
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:group ref="tei:model.noteLike"/>
           <xs:group ref="tei:model.biblLike"/>
+          <xs:group ref="tei:model.ptrLike"/>
           <xs:element ref="tei:linkGrp"/>
           <xs:element ref="tei:link"/>
           <xs:element ref="tei:idno"/>
-          <xs:element ref="tei:ptr"/>
         </xs:choice>
         <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.eventLike"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -18863,9 +18880,9 @@ Sample values include: 1] primary; 2] other; 3] paid; 4] unpaid</xs:documentatio
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:group ref="tei:model.noteLike"/>
           <xs:group ref="tei:model.biblLike"/>
+          <xs:group ref="tei:model.ptrLike"/>
           <xs:element ref="tei:linkGrp"/>
           <xs:element ref="tei:link"/>
-          <xs:element ref="tei:ptr"/>
         </xs:choice>
         <xs:group minOccurs="0" maxOccurs="unbounded" ref="tei:model.personLike"/>
       </xs:sequence>
@@ -18904,7 +18921,7 @@ Sample values include: 1] primary; 2] other; 3] paid; 4] unpaid</xs:documentatio
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:group ref="tei:model.personPart"/>
           <xs:group ref="tei:model.global"/>
-          <xs:element ref="tei:ptr"/>
+          <xs:group ref="tei:model.ptrLike"/>
         </xs:choice>
       </xs:choice>
       <xs:attributeGroup ref="tei:att.global.attributes"/>
@@ -19252,8 +19269,8 @@ Sample values include: 1] e (e); 2] he (he); 3] she (she); 4] they (they)</xs:do
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:group ref="tei:model.noteLike"/>
           <xs:group ref="tei:model.biblLike"/>
+          <xs:group ref="tei:model.ptrLike"/>
           <xs:element ref="tei:idno"/>
-          <xs:element ref="tei:ptr"/>
           <xs:element ref="tei:linkGrp"/>
           <xs:element ref="tei:link"/>
         </xs:choice>
@@ -20544,7 +20561,7 @@ Suggested values include: 1] persuade; 2] express; 3] inform; 4] entertain</xs:d
   <xs:attributeGroup name="att.global.linking.attribute.next">
     <xs:attribute name="next">
       <xs:annotation>
-        <xs:documentation>points to the next element of a virtual aggregate of which the current element is part.</xs:documentation>
+        <xs:documentation>(next) points to the next element of a virtual aggregate of which the current element is part.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:restriction base="xs:anyURI">
@@ -22639,14 +22656,14 @@ Sample values include: 1] ignorance; 2] incompleteness; 3] credibility; 4] impre
   <xs:attributeGroup name="att.repeatable.attribute.minOccurs">
     <xs:attribute name="minOccurs" default="1" type="xs:nonNegativeInteger">
       <xs:annotation>
-        <xs:documentation>(minimum number of occurences) indicates the smallest number of times this component may occur.</xs:documentation>
+        <xs:documentation>(minimum number of occurrences) indicates the smallest number of times this component may occur.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="att.repeatable.attribute.maxOccurs">
     <xs:attribute name="maxOccurs" default="1">
       <xs:annotation>
-        <xs:documentation>(maximum number of occurences) indicates the largest number of times this component may occur.</xs:documentation>
+        <xs:documentation>(maximum number of occurrences) indicates the largest number of times this component may occur.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="xs:nonNegativeInteger">
@@ -23555,16 +23572,16 @@ Sample values include: 1] TEI (text encoding initiative); 2] DBK (docbook); 3] X
       <xs:attributeGroup ref="tei:att.global.attributes"/>
       <xs:attributeGroup ref="tei:att.combinable.attributes"/>
       <xs:attributeGroup ref="tei:att.translatable.attributes"/>
-      <xs:attribute name="ident" type="xs:string">
+      <xs:attribute name="ident" type="xs:Name">
         <xs:annotation>
-          <xs:documentation>specifies the remark concerned.</xs:documentation>
+          <xs:documentation>supplies the identifier by which the remarks may be referenced.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="listRef">
     <xs:annotation>
-      <xs:documentation>(list of references) supplies a list of significant references in the current document or elsewhere.</xs:documentation>
+      <xs:documentation>(list of references) supplies a list of significant references in the current document or elsewhere. [23.4.1. Description of Components 24.5.1. Making a Unified ODD]</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
@@ -24163,7 +24180,7 @@ Suggested values include: 1] web; 2] print; 3] plaintext</xs:documentation>
   </xs:element>
   <xs:element name="outputRendition">
     <xs:annotation>
-      <xs:documentation>describes the rendering or appearance intended for all occurrences of an element in a specified context for a specified type of output.</xs:documentation>
+      <xs:documentation>describes the rendering or appearance intended for all occurrences of an element in a specified context for a specified type of output. [23.5.4.2. Output Rendition ]</xs:documentation>
     </xs:annotation>
     <xs:complexType mixed="true">
       <xs:attributeGroup ref="tei:att.global.attributes"/>
@@ -24182,7 +24199,7 @@ Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</xs:d
   </xs:element>
   <xs:element name="paramList">
     <xs:annotation>
-      <xs:documentation>list of parameter specifications.</xs:documentation>
+      <xs:documentation>list of parameter specifications. [23.5.4.5. Behaviours and their parameters 23.5.4.8. Defining a processing model]</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
@@ -24708,12 +24725,12 @@ Suggested values include: 1] schematron (ISO Schematron)</xs:documentation>
       <xs:attributeGroup ref="tei:att.global.attributes"/>
       <xs:attribute name="minOccurs" default="1" type="xs:nonNegativeInteger">
         <xs:annotation>
-          <xs:documentation>(minimum number of occurences) indicates the minimum number of times this datatype may occur in an instance of the attribute being defined.</xs:documentation>
+          <xs:documentation>(minimum number of occurrences) indicates the minimum number of times this datatype may occur in an instance of the attribute being defined.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="maxOccurs" default="1">
         <xs:annotation>
-          <xs:documentation>(maximum number of occurences) indicates the maximum number of times this datatype may occur in an instance of the attribute being defined.</xs:documentation>
+          <xs:documentation>(maximum number of occurrences) indicates the maximum number of times this datatype may occur in an instance of the attribute being defined.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:union memberTypes="xs:nonNegativeInteger">
@@ -24993,4 +25010,4 @@ Suggested values include: 1] schematron (ISO Schematron)</xs:documentation>
       <xs:attributeGroup ref="tei:att.global.attributes"/>
     </xs:complexType>
   </xs:element>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/schema_data/xlink.xsd
+++ b/neuxml/schema_data/xlink.xsd
@@ -72,4 +72,4 @@
   <attributeGroup name="emptyLink">
     <attribute name="type" type="string" fixed="none" form="qualified"/> 
   </attributeGroup>
-<!--Downloaded by neuxml 1.1.3 on 2025-04-01--></schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></schema>

--- a/neuxml/schema_data/xml.xsd
+++ b/neuxml/schema_data/xml.xsd
@@ -113,4 +113,4 @@
   <xs:attribute ref="xml:space"/>
  </xs:attributeGroup>
 
-<!--Downloaded by neuxml 1.1.3 on 2025-04-03--></xs:schema>
+<!--Downloaded by neuxml 1.1.0.dev0 on 2025-08-20--></xs:schema>

--- a/neuxml/xmlmap/core.py
+++ b/neuxml/xmlmap/core.py
@@ -35,21 +35,6 @@ __all__ = [
     "load_xslt",
 ]
 
-# NB: When parsing XML in this module, we explicitly create a new parser
-#   each time. Without this, lxml 2.2.7 uses a global default parser. When
-#   parsing strings, lxml appears to set that parser into no-network mode,
-#   causing subsequent network-based parses to fail. Specifically, under
-#   lxml 2.2.7, the second call here fails::
-#
-#   >>> etree.fromstring('<foo/>') # set global parser to no-network
-#   >>> etree.parse('http://www.w3.org/2001/xml.xsd') # fails in no-network mode
-#
-#   If we simply construct a separate parser each time, parses will be
-#   marginally slower, but this lxml bug will not affect us.
-#
-#   This lxml behavior has been logged as a bug:
-#   https://bugs.launchpad.net/lxml/+bug/673205
-
 
 def parseUri(stream, uri=None):
     """Read an XML document from a URI, and return a :mod:`lxml.etree`
@@ -92,6 +77,7 @@ def loadSchema(uri, base_uri=None):
         raise IOError("Failed to load schema %s : %s" % (error_uri, io_err))
     except etree.XMLSchemaParseError as parse_err:
         # re-raise as a schema parse error, but ensure includes details about schema being loaded
+        print(parse_err)
         raise etree.XMLSchemaParseError(
             "Failed to parse schema %s -- %s" % (error_uri, parse_err)
         )
@@ -564,16 +550,13 @@ class XmlObject(object, metaclass=XmlObjectType):
         )  # regular text or text after a node
 
 
-""" April 2016. Removing Urllib2Resolver so we can support
-  loading local copies of schema and skip validation in get_xml_parser """
-
-
 def _get_xmlparser(xmlclass=XmlObject, validate=False, resolver=None):
     """Initialize an instance of :class:`lxml.etree.XMLParser` with appropriate
     settings for validation.  If validation is requested and the specified
     instance of :class:`XmlObject` has an XSD_SCHEMA defined, that will be used.
     Otherwise, uses DTD validation. Switched resolver to None to skip validation.
     """
+    opts = {}
     if validate:
         if hasattr(xmlclass, "XSD_SCHEMA") and xmlclass.XSD_SCHEMA is not None:
             # If the schema has already been loaded, use that.
@@ -583,10 +566,10 @@ def _get_xmlparser(xmlclass=XmlObject, validate=False, resolver=None):
             # otherwise, load the schema
             if xmlschema is None:
                 xmlschema = loadSchema(xmlclass.XSD_SCHEMA)
-            opts = {"schema": xmlschema}
+            opts["schema"] = xmlschema
         else:
             # if configured XmlObject does not have a schema defined, assume DTD validation
-            opts = {"dtd_validation": True}
+            opts["dtd_validation"] = True
     else:
         # If validation is not requested, then the parsing should fail
         # only for well-formedness issues.
@@ -596,7 +579,7 @@ def _get_xmlparser(xmlclass=XmlObject, validate=False, resolver=None):
         # them. However, the XML spec declares ID uniqueness as a
         # validation constraint, not a well-formedness
         # constraint. (See https://www.w3.org/TR/xml/#id.)
-        opts = {"collect_ids": False}
+        opts["collect_ids"] = False
 
     parser = etree.XMLParser(**opts)
 

--- a/neuxml/xmlmap/dc.py
+++ b/neuxml/xmlmap/dc.py
@@ -21,7 +21,7 @@ except ImportError:
     # use rdflib if it's available, but it's ok if it's not
     rdflib = None
 
-from neuxml import xmlmap
+from neuxml import xmlmap, XMLCATALOG_DIR
 
 
 class _BaseDublinCore(xmlmap.XmlObject):
@@ -105,7 +105,8 @@ class DublinCore(_BaseDublinCore):
     "list of all DC elements as instances of :class:`DublinCoreElement`"
 
     # RDF declaration of the Recommended DCMI types
-    DCMI_TYPES_RDF = "http://dublincore.org/2010/10/11/dctype.rdf"
+    # DCMI_TYPES_RDF = "http://dublincore.org/2010/10/11/dctype.rdf"
+    DCMI_TYPES_RDF = f"{XMLCATALOG_DIR}/dctype.rdf"
     DCMI_TYPE_URI = "http://purl.org/dc/dcmitype/"
     if rdflib:
         DCMI_TYPE_URI = rdflib.URIRef(DCMI_TYPE_URI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,22 +29,29 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup :: XML",
 ]
-dependencies = ["ply>=3.8", "lxml>=3.4", "rdflib>=3.0"]
+dependencies = ["ply>=3.8", "lxml>=3.4"]
 
 [project.optional-dependencies]
+rdf  = ["rdflib>=3.0"]
+test = ["pytest>=4.6",
+    "pytest-cov",
+    "pytest-socket"
+]
 dev = [
     "sphinx>=1.3.5",
-    "mock",
-    "pytest>=4.6",
-    "pytest-cov",
-    "pytest-socket",
-    "requests",
+    "requests",  # for downloading schemas
     "pre-commit",
+    "neuxml[test]",
+    "neuxml[rdf]"
 ]
 
 [project.urls]
 Repository = "https://github.com/Princeton-CDH/neuxml"
 Changelog = "https://github.com/Princeton-CDH/neuxml/blob/main/CHANGELOG.rst"
+
+[project.scripts]
+neuxml-refresh-catalog = "neuxml.catalog:refresh_cli"
+
 
 [tool.hatch.build]
 artifacts = ["neuxml/xpath/lextab.py", "neuxml/xpath/parsetab.py"]

--- a/test/test_xmlmap/test_dc.py
+++ b/test/test_xmlmap/test_dc.py
@@ -15,8 +15,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pytest
 import unittest
+
+import pytest
+
+try:
+    import rdflib
+except ImportError:
+    # use rdflib if it's available, but it's ok if it's not
+    rdflib = None
+
 
 from neuxml.xmlmap.core import load_xmlobject_from_string
 from neuxml.xmlmap.dc import DublinCore
@@ -126,9 +134,10 @@ class TestDc(unittest.TestCase):
             b'xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"' in dc_xml
         )
 
-    def test_isvalid(self):
+    def test_is_valid(self):
         self.assertTrue(self.dc.is_valid())
 
+    def test_is_not_valid(self):
         invalid = """<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
   <dc:title>Feet in the Fire</dc:title>
         <not_a_dc_field>bogus</not_a_dc_field>
@@ -137,7 +146,7 @@ class TestDc(unittest.TestCase):
         invalid_dc = load_xmlobject_from_string(invalid, DublinCore)
         self.assertFalse(invalid_dc.is_valid())
 
-    @pytest.mark.skip(reason="request to real server by RDFLib")
+    @pytest.mark.skipif(rdflib is None, reason="requires rdflib")
     def test_dcmitypes(self):
         types = self.dc.dcmi_types
         self.assertTrue(isinstance(types, list))


### PR DESCRIPTION
**Associated Issue:** #7

### Changes in this PR

- update catalog list of schemas and regenerate
- make refresh catalog runnable as cli script
- make rdflib an optional dependency
   - add rdflib as an option in github test matrix
- add dc types rdf file to catalog and reference there

